### PR TITLE
upgrade to chainguard images and full static build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM cgr.dev/chainguard/go:latest AS builder
 
 WORKDIR /src
 
@@ -10,7 +10,8 @@ COPY . .
 
 RUN hack/build.sh
 
-FROM gcr.io/distroless/static-debian11:nonroot
+# FROM gcr.io/distroless/static-debian11:nonroot
+FROM cgr.dev/chainguard/static:latest
 
 WORKDIR /
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # build basic golang server
-go build -o ./server ./cmd/server/.
+CGO_ENABLED=0 go build -o ./server ./cmd/server/.
 
 # build the Web Assebly binary we'll serve
 GOOS=js GOARCH=wasm go build -o ./jwt.wasm ./cmd/wasm/.


### PR DESCRIPTION
upgrade to chainguard images and full static build


chainguard are nice images to build on which come with SBOMs and have a solid APK-based system for getting updates pushed. They’re cutting out the middlemen (i.e. upstream -> debian -> ubuntu -> docker -> you) and just making container-specific images directly compiled from upstream sources (i.e. upstream -> wolfi -> you) so CVEs can be patched quickly 